### PR TITLE
Add check for missing IdentityProvider configuration.

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -16,6 +16,8 @@ ClusterPipeline
 ClusterPubSub
 ConnectionPool
 CoreCommands
+Entra
+EntraID
 EVAL
 EVALSHA
 Failback
@@ -30,6 +32,7 @@ GeoRadiusParam
 GeoRadiusStoreParam
 GeoUnit
 GraphCommands
+Gradle
 Grokzen's
 HostAndPort
 HostnameVerifier
@@ -41,6 +44,7 @@ JSONArray
 JSONCommands
 Jaeger
 Javadocs
+Jedis
 ListPosition
 Ludovico
 Magnocavallo
@@ -59,6 +63,7 @@ POJOs
 PubSub
 Queable
 READONLY
+Reauthentication
 RediSearch
 RediSearchCommands
 RedisBloom

--- a/entraid/src/main/java/redis/clients/authentication/entraid/EntraIDTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/EntraIDTokenAuthConfigBuilder.java
@@ -118,6 +118,11 @@ public class EntraIDTokenAuthConfigBuilder
             throw new RedisEntraIDException(
                     "Cannot have both customEntraIdAuthenticationSupplier and ServicePrincipal/ManagedIdentity!");
         }
+        if (this.customEntraIdAuthenticationSupplier == null && spi == null && mii == null) {
+            throw new RedisEntraIDException(
+                "Missing configuration. One of customEntraIdAuthenticationSupplier, ServicePrincipal or ManagedIdentity must be configured!");
+        }
+
         if (spi != null) {
             super.identityProviderConfig(
                 new EntraIDIdentityProviderConfig(spi, scopes, tokenRequestExecTimeoutInMs));

--- a/entraid/src/test/java/redis/clients/authentication/EntraIDUnitTests.java
+++ b/entraid/src/test/java/redis/clients/authentication/EntraIDUnitTests.java
@@ -554,6 +554,7 @@ public class EntraIDUnitTests {
         int maxAttemptsToRetry = 6;
         int tokenRequestExecTimeoutInMs = 401;
         TokenAuthConfig tokenAuthConfig = EntraIDTokenAuthConfigBuilder.builder()
+                .clientId("testClientId").secret("testSecret")
                 .expirationRefreshRatio(refreshRatio).delayInMsToRetry(delayInMsToRetry)
                 .lowerRefreshBoundMillis(lowerRefreshBoundMillis)
                 .maxAttemptsToRetry(maxAttemptsToRetry)

--- a/entraid/src/test/java/redis/clients/authentication/EntraIDUnitTests.java
+++ b/entraid/src/test/java/redis/clients/authentication/EntraIDUnitTests.java
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import com.microsoft.aad.msal4j.IAccount;
+import com.microsoft.aad.msal4j.ITenantProfile;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
 import org.junit.Test;
@@ -64,6 +66,7 @@ import redis.clients.authentication.entraid.EntraIDIdentityProvider;
 import redis.clients.authentication.entraid.EntraIDTokenAuthConfigBuilder;
 import redis.clients.authentication.entraid.JWToken;
 import redis.clients.authentication.entraid.ManagedIdentityInfo;
+import redis.clients.authentication.entraid.RedisEntraIDException;
 import redis.clients.authentication.entraid.ServicePrincipalInfo;
 import redis.clients.authentication.entraid.ManagedIdentityInfo.UserManagedIdentityType;
 
@@ -142,6 +145,28 @@ public class EntraIDUnitTests {
             configWithManagedId.getProvider();
         }
     }
+
+    @Test
+    public void testConfigBuilderThrowsErrorIfMissconfigured() {
+
+        // Missing Configuration
+        assertThrows(RedisEntraIDException.class,() -> EntraIDTokenAuthConfigBuilder.builder().build());
+
+        // spi & mpi configured
+        assertThrows(RedisEntraIDException.class,() -> EntraIDTokenAuthConfigBuilder.builder()
+            .clientId("clientid")
+            .secret("secret")
+            .systemAssignedManagedIdentity()
+            .build());
+
+        // spi || mpi  && customEntraIdAuthenticationSupplier configured
+        assertThrows(RedisEntraIDException.class,() -> EntraIDTokenAuthConfigBuilder.builder()
+            .clientId("clientid")
+            .secret("secret")
+            .customEntraIdAuthenticationSupplier(() -> mock(IAuthenticationResult.class))
+            .build());
+    }
+
 
     // T.1.2
     // Implement a stubbed IdentityProvider and verify that the TokenManager works normally and handles:


### PR DESCRIPTION
It can happen that client ID/secret are not set for some reason (e.g read from env variables but because of misconfiguration null values are used). In such case, identityProviderConfig will remain null and generate NPE when later used.

Introducing an additional  check that at least one of the expected configuration settings is applied before invoking build()