### PR TITLE
Add support for DefaultAzureCredentials

### DIFF
--- a/.github/workflows/entraid_integration.yml
+++ b/.github/workflows/entraid_integration.yml
@@ -64,3 +64,4 @@ jobs:
           AZURE_CERT: ${{secrets.AZURE_CERT}}
           AZURE_PRIVATE_KEY: ${{secrets.AZURE_PRIVATE_KEY}}
           AZURE_REDIS_SCOPES: ${{secrets.AZURE_REDIS_SCOPES}}
+          AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}

--- a/core/src/main/java/redis/clients/authentication/core/Dispatcher.java
+++ b/core/src/main/java/redis/clients/authentication/core/Dispatcher.java
@@ -1,5 +1,8 @@
 /*
- * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ * Copyright 2024, Redis Ltd. and Contributors 
+ * All rights reserved. 
+ * 
+ * Licensed under the MIT License.
  */
 package redis.clients.authentication.core;
 

--- a/core/src/main/java/redis/clients/authentication/core/RenewalScheduler.java
+++ b/core/src/main/java/redis/clients/authentication/core/RenewalScheduler.java
@@ -1,5 +1,8 @@
 /*
- * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ * Copyright 2024, Redis Ltd. and Contributors 
+ * All rights reserved. 
+ * 
+ * Licensed under the MIT License.
  */
 package redis.clients.authentication.core;
 

--- a/core/src/main/java/redis/clients/authentication/core/TokenManager.java
+++ b/core/src/main/java/redis/clients/authentication/core/TokenManager.java
@@ -1,5 +1,8 @@
 /*
- * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ * Copyright 2024, Redis Ltd. and Contributors 
+ * All rights reserved. 
+ * 
+ * Licensed under the MIT License.
  */
 package redis.clients.authentication.core;
 

--- a/entraid/pom.xml
+++ b/entraid/pom.xml
@@ -67,6 +67,11 @@
 		<artifactId>msal4j</artifactId>
 		<version>1.17.2</version>
 	</dependency>
+	<dependency>
+		<groupId>com.azure</groupId>
+		<artifactId>azure-identity</artifactId>
+		<version>1.15.3</version>
+	</dependency>
     <dependency>
 		<groupId>junit</groupId>
 		<artifactId>junit</artifactId>

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProvider.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ */
+package redis.clients.authentication.entraid;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.DefaultAzureCredential;
+import redis.clients.authentication.core.IdentityProvider;
+import redis.clients.authentication.core.Token;
+
+public final class AzureIdentityProvider implements IdentityProvider {
+
+    private Supplier<AccessToken> accessTokenSupplier;
+
+    public AzureIdentityProvider(DefaultAzureCredential defaultAzureCredential, Set<String> scopes,
+            int timeout) {
+        TokenRequestContext ctx = new TokenRequestContext()
+                .setScopes(new ArrayList<String>(scopes));
+        accessTokenSupplier = () -> defaultAzureCredential.getToken(ctx)
+                .block(Duration.ofMillis(timeout));
+    }
+
+    @Override
+    public Token requestToken() {
+        return new JWToken(accessTokenSupplier.get().getToken());
+    }
+}

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProvider.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProvider.java
@@ -1,5 +1,8 @@
 /*
- * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ * Copyright 2024, Redis Ltd. and Contributors 
+ * All rights reserved. 
+ * 
+ * Licensed under the MIT License.
  */
 package redis.clients.authentication.entraid;
 
@@ -13,6 +16,38 @@ import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.DefaultAzureCredential;
 import redis.clients.authentication.core.IdentityProvider;
 import redis.clients.authentication.core.Token;
+
+/**
+ * AzureIdentityProvider is an implementation of the IdentityProvider interface
+ * that uses Azure's DefaultAzureCredential to obtain access tokens.
+ * 
+ * <p>This class is designed to work with Azure's identity platform to provide
+ * authentication tokens for accessing Azure resources. It uses a 
+ * DefaultAzureCredential to request tokens with specified scopes and a timeout(in milliseconds). 
+ * For most cases you will not need to use it directly since AzureTokenAuthConfigBuilder 
+ * will do the work for you as shown in the example below:
+ * <pre>
+ * {@code
+ * TokenAuthConfig config = AzureTokenAuthConfigBuilder.builder()
+ *          .defaultAzureCredential(new DefaultAzureCredential()).build();
+ * }
+ * </pre>
+ * <p>In you case you need your own implementation for relevant reasons, you can use it as follows:
+ * <pre>
+ * {@code
+ * Set<String> scopes = new HashSet<>(Arrays.asList("https://redis.azure.com/.default"));
+ * AzureIdentityProvider provider = new AzureIdentityProvider(
+ *      new DefaultAzureCredentialBuilder().build(), scopes, 5000);
+ * TokenAuthConfig config = AzureTokenAuthConfigBuilder.builder().identityProviderConfig(()-> provider)).build();
+ * }
+ * </pre>
+ * 
+ * <p>Thread Safety: This class is thread-safe as long as the provided 
+ * DefaultAzureCredential is thread-safe.
+ * 
+ * @see redis.clients.authentication.entraid.AzureTokenAuthConfigBuilder
+ * @see com.azure.identity.DefaultAzureCredentialBuilder
+ */
 
 public final class AzureIdentityProvider implements IdentityProvider {
 

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProviderConfig.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProviderConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package redis.clients.authentication.entraid;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.azure.identity.DefaultAzureCredential;
+
+import redis.clients.authentication.core.IdentityProvider;
+import redis.clients.authentication.core.IdentityProviderConfig;
+
+public final class AzureIdentityProviderConfig implements IdentityProviderConfig {
+
+    private final Supplier<IdentityProvider> providerSupplier;
+
+    public AzureIdentityProviderConfig(DefaultAzureCredential defaultAzureCredential, Set<String> scopes, int timeout) {
+        providerSupplier = () -> new AzureIdentityProvider(defaultAzureCredential, scopes, timeout);
+    }
+
+    @Override
+    public IdentityProvider getProvider() {
+        return providerSupplier.get();
+    }
+}

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProviderConfig.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProviderConfig.java
@@ -14,6 +14,39 @@ import com.azure.identity.DefaultAzureCredential;
 import redis.clients.authentication.core.IdentityProvider;
 import redis.clients.authentication.core.IdentityProviderConfig;
 
+/**
+ * Configuration class for Azure Identity Provider.
+ * This class implements the {@link IdentityProviderConfig} interface and provides
+ * a configuration for creating an {@link AzureIdentityProvider} instance.
+ * 
+ * <p>This class uses {@link DefaultAzureCredential} for authentication and allows
+ * specifying scopes and a timeout(in milliseconds) for the identity provider.</p>
+ * For most cases you will not need to use it directly since AzureTokenAuthConfigBuilder 
+ * will do the work for you as shown in the example below:
+ * <pre>
+ * {@code
+ * TokenAuthConfig config = AzureTokenAuthConfigBuilder.builder()
+ *          .defaultAzureCredential(new DefaultAzureCredentialBuilder()).build();
+ * } 
+ * </pre>
+ * <p>In you case you need your own implementation for relevant reasons, you can use it as follows:
+ * <pre>
+ * {@code
+ * DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+ * Set<String> scopes = Set.of("https://redis.azure.com/.default");
+ * AzureIdentityProviderConfig azureIDPConfig = new AzureIdentityProviderConfig(credential, scopes, 5000);
+ * TokenAuthConfig config = AzureTokenAuthConfigBuilder.builder().identityProviderConfig(azureIDPConfig).build();
+ * }
+ * </pre>
+ * 
+ * For more information and details on how to use, please see:
+ * https://github.com/redis/jedis/blob/master/docs/advanced-usage.md#token-based-authentication
+ * https://github.com/redis/lettuce/blob/main/docs/user-guide/connecting-redis.md#microsoft-entra-id-authentication
+ * 
+ * @see IdentityProviderConfig
+ * @see AzureIdentityProvider
+ * @see DefaultAzureCredentialBuilder
+ */
 public final class AzureIdentityProviderConfig implements IdentityProviderConfig {
 
     private final Supplier<IdentityProvider> providerSupplier;

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProviderConfig.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureIdentityProviderConfig.java
@@ -45,7 +45,7 @@ import redis.clients.authentication.core.IdentityProviderConfig;
  * 
  * @see IdentityProviderConfig
  * @see AzureIdentityProvider
- * @see DefaultAzureCredentialBuilder
+ * @see DefaultAzureCredential
  */
 public final class AzureIdentityProviderConfig implements IdentityProviderConfig {
 

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
@@ -1,5 +1,8 @@
 /*
- * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ * Copyright 2024, Redis Ltd. and Contributors 
+ * All rights reserved. 
+ * 
+ * Licensed under the MIT License.
  */
 package redis.clients.authentication.entraid;
 
@@ -11,6 +14,38 @@ import com.azure.identity.DefaultAzureCredential;
 import redis.clients.authentication.core.TokenAuthConfig;
 import redis.clients.authentication.core.TokenManagerConfig;
 
+/**
+ * Builder class for configuring Azure Token Authentication via a DefaultAzureCredential.
+ * It builds a TokenAuthConfig object which can be used to authenticate with Azure resources. 
+ * This class extends {@link TokenAuthConfig.Builder} and implements {@link AutoCloseable}.
+ * It provides methods to configure various parameters for Azure Token Authentication.
+ * 
+ * <p>Default values:</p>
+ * <ul>
+ *   <li>{@code DEFAULT_EXPIRATION_REFRESH_RATIO}: 0.75F</li>
+ *   <li>{@code DEFAULT_LOWER_REFRESH_BOUND_MILLIS}: 2 * 60 * 1000</li>
+ *   <li>{@code DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS}: 1000</li>
+ *   <li>{@code DEFAULT_MAX_ATTEMPTS_TO_RETRY}: 5</li>
+ *   <li>{@code DEFAULT_DELAY_IN_MS_TO_RETRY}: 100</li>
+ *   <li>{@code DEFAULT_SCOPES}: "https://redis.azure.com/.default"</li>
+ * </ul>
+ * 
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * AzureTokenAuthConfigBuilder builder = AzureTokenAuthConfigBuilder.builder()
+ *     .defaultAzureCredential(new DefaultAzureCredentialBuilder.build())
+ *     .scopes(Collections.singleton("https://example.com/.default"))
+ *     .tokenRequestExecTimeoutInMs(2000);
+ * TokenAuthConfig config = builder.build();
+ * }</pre>
+ * 
+ * <p>This class is also {@link AutoCloseable}, and resources can be cleaned
+ * up by calling {@link #close()}.</p>
+ * 
+ * @see TokenAuthConfig.Builder
+ * @see DefaultAzureCredentialBuilder
+ * @see DefaultAzureCredential
+ */
 public class AzureTokenAuthConfigBuilder
         extends TokenAuthConfig.Builder<AzureTokenAuthConfigBuilder> implements AutoCloseable {
     public static final float DEFAULT_EXPIRATION_REFRESH_RATIO = 0.75F;

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
@@ -43,7 +43,6 @@ import redis.clients.authentication.core.TokenManagerConfig;
  * up by calling {@link #close()}.</p>
  * 
  * @see TokenAuthConfig.Builder
- * @see DefaultAzureCredentialBuilder
  * @see DefaultAzureCredential
  */
 public class AzureTokenAuthConfigBuilder

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ */
+package redis.clients.authentication.entraid;
+
+import java.util.Collections;
+import java.util.Set;
+
+import com.azure.identity.DefaultAzureCredential;
+
+import redis.clients.authentication.core.TokenAuthConfig;
+import redis.clients.authentication.core.TokenManagerConfig;
+
+public class AzureTokenAuthConfigBuilder
+        extends TokenAuthConfig.Builder<AzureTokenAuthConfigBuilder> implements AutoCloseable {
+    public static final float DEFAULT_EXPIRATION_REFRESH_RATIO = 0.75F;
+    public static final int DEFAULT_LOWER_REFRESH_BOUND_MILLIS = 2 * 60 * 1000;
+    public static final int DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS = 1000;
+    public static final int DEFAULT_MAX_ATTEMPTS_TO_RETRY = 5;
+    public static final int DEFAULT_DELAY_IN_MS_TO_RETRY = 100;
+    public static final Set<String> DEFAULT_SCOPES = Collections.singleton("https://redis.azure.com/.default");;
+
+    private DefaultAzureCredential defaultAzureCredential;
+    private Set<String> scopes = DEFAULT_SCOPES;
+    private int tokenRequestExecTimeoutInMs;
+
+    public AzureTokenAuthConfigBuilder() {
+        this.expirationRefreshRatio(DEFAULT_EXPIRATION_REFRESH_RATIO)
+                .lowerRefreshBoundMillis(DEFAULT_LOWER_REFRESH_BOUND_MILLIS)
+                .tokenRequestExecTimeoutInMs(DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS)
+                .maxAttemptsToRetry(DEFAULT_MAX_ATTEMPTS_TO_RETRY)
+                .delayInMsToRetry(DEFAULT_DELAY_IN_MS_TO_RETRY);
+    }
+
+    public AzureTokenAuthConfigBuilder defaultAzureCredential(
+            DefaultAzureCredential defaultAzureCredential) {
+        this.defaultAzureCredential = defaultAzureCredential;
+        return this;
+    }
+
+    public AzureTokenAuthConfigBuilder scopes(Set<String> scopes) {
+        this.scopes = scopes;
+        return this;
+    }
+
+    @Override
+    public AzureTokenAuthConfigBuilder tokenRequestExecTimeoutInMs(
+            int tokenRequestExecTimeoutInMs) {
+        super.tokenRequestExecTimeoutInMs(tokenRequestExecTimeoutInMs);
+        this.tokenRequestExecTimeoutInMs = tokenRequestExecTimeoutInMs;
+        return this;
+    }
+
+    public TokenAuthConfig build() {
+        super.identityProviderConfig(new AzureIdentityProviderConfig(defaultAzureCredential, scopes,
+                tokenRequestExecTimeoutInMs));
+        return super.build();
+    }
+
+    @Override
+    public void close() throws Exception {
+        defaultAzureCredential = null;
+        scopes = null;
+    }
+
+    public static AzureTokenAuthConfigBuilder builder() {
+        return new AzureTokenAuthConfigBuilder();
+    }
+
+    public static AzureTokenAuthConfigBuilder from(AzureTokenAuthConfigBuilder sample) {
+        TokenAuthConfig tokenAuthConfig = TokenAuthConfig.Builder.from(sample).build();
+        TokenManagerConfig tokenManagerConfig = tokenAuthConfig.getTokenManagerConfig();
+
+        AzureTokenAuthConfigBuilder builder = (AzureTokenAuthConfigBuilder) new AzureTokenAuthConfigBuilder()
+                .expirationRefreshRatio(tokenManagerConfig.getExpirationRefreshRatio())
+                .lowerRefreshBoundMillis(tokenManagerConfig.getLowerRefreshBoundMillis())
+                .tokenRequestExecTimeoutInMs(tokenManagerConfig.getTokenRequestExecTimeoutInMs())
+                .maxAttemptsToRetry(tokenManagerConfig.getRetryPolicy().getMaxAttempts())
+                .delayInMsToRetry(tokenManagerConfig.getRetryPolicy().getdelayInMs())
+                .identityProviderConfig(tokenAuthConfig.getIdentityProviderConfig());
+        builder.scopes = sample.scopes;
+        return builder;
+    }
+}

--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
@@ -22,7 +22,7 @@ public class AzureTokenAuthConfigBuilder
 
     private DefaultAzureCredential defaultAzureCredential;
     private Set<String> scopes = DEFAULT_SCOPES;
-    private int tokenRequestExecTimeoutInMs;
+    private int tokenRequestExecTimeoutInMs = DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS;
 
     public AzureTokenAuthConfigBuilder() {
         this.expirationRefreshRatio(DEFAULT_EXPIRATION_REFRESH_RATIO)

--- a/entraid/src/main/java/redis/clients/authentication/entraid/EntraIDTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/EntraIDTokenAuthConfigBuilder.java
@@ -18,6 +18,60 @@ import redis.clients.authentication.core.TokenManagerConfig;
 import redis.clients.authentication.entraid.ManagedIdentityInfo.UserManagedIdentityType;
 import redis.clients.authentication.entraid.ServicePrincipalInfo.ServicePrincipalAccess;
 
+/**
+ * Builder class for configuring EntraID token authentication.
+ * This class provides methods to set various configuration options for EntraID token authentication.
+ * It extends the TokenAuthConfig.Builder class and implements AutoCloseable.
+ * 
+ * <p>Default values:</p>
+ * <ul>
+ *   <li>DEFAULT_EXPIRATION_REFRESH_RATIO: 0.75F</li>
+ *   <li>DEFAULT_LOWER_REFRESH_BOUND_MILLIS: 120000 (2 minutes)</li>
+ *   <li>DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS: 1000 (1 second)</li>
+ *   <li>DEFAULT_MAX_ATTEMPTS_TO_RETRY: 5</li>
+ *   <li>DEFAULT_DELAY_IN_MS_TO_RETRY: 100 (0.1 second)</li>
+ * </ul>
+ * 
+ * <p>Configuration options:</p>
+ * <ul>
+ *   <li>{@link #clientId(String)}: Sets the client ID.</li>
+ *   <li>{@link #secret(String)}: Sets the client secret and configures access with secret.</li>
+ *   <li>{@link #key(PrivateKey, X509Certificate)}: Sets the private key and certificate, 
+ *      and configures access with certificate.</li>
+ *   <li>{@link #authority(String)}: Sets the authority URL.</li>
+ *   <li>{@link #systemAssignedManagedIdentity()}: Configures system-assigned managed identity.</li>
+ *   <li>{@link #userAssignedManagedIdentity(UserManagedIdentityType, String)}: 
+ *      Configures user-assigned managed identity.</li>
+ *   <li>{@link #customEntraIdAuthenticationSupplier(Supplier)}: Sets a custom authentication supplier.</li>
+ *   <li>{@link #scopes(Set)}: Sets the scopes for the token request.</li>
+ *   <li>{@link #tokenRequestExecTimeoutInMs(int)}: Sets the token request execution timeout in milliseconds.</li>
+ * </ul>
+ * 
+ * <p>Usage:</p>
+ * <pre>
+ * {@code
+ * EntraIDTokenAuthConfigBuilder builder = EntraIDTokenAuthConfigBuilder.builder()
+ *     .clientId("your-client-id")
+ *     .secret("your-secret")
+ *     .authority("https://login.microsoftonline.com/your-tenant-id")
+ *     .scopes(Set.of("https://redis.azure.com/.default"))
+ *     .build();
+ * }
+ * </pre>
+ * 
+ * <p>Note:</p>
+ * <ul>
+ *   <li>Only one of ServicePrincipal, ManagedIdentity or customEntraIdAuthenticationSupplier can be configured.</li>
+ *   <li>Throws RedisEntraIDException if conflicting configurations are provided.</li>
+ * </ul>
+ * For more information and details on how to use, please see:
+ * <p>https://github.com/redis/jedis/blob/master/docs/advanced-usage.md#token-based-authentication
+ * <p>https://github.com/redis/lettuce/blob/main/docs/user-guide/connecting-redis.md#microsoft-entra-id-authentication
+ * 
+ * @see TokenAuthConfig.Builder
+ * @see AutoCloseable
+ * 
+ */
 public class EntraIDTokenAuthConfigBuilder
         extends TokenAuthConfig.Builder<EntraIDTokenAuthConfigBuilder> implements AutoCloseable {
     public static final float DEFAULT_EXPIRATION_REFRESH_RATIO = 0.75F;

--- a/entraid/src/test/java/redis/clients/authentication/AzureIdentityProviderIntegrationTests.java
+++ b/entraid/src/test/java/redis/clients/authentication/AzureIdentityProviderIntegrationTests.java
@@ -1,5 +1,8 @@
 /*
- * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ * Copyright 2024, Redis Ltd. and Contributors 
+ * All rights reserved. 
+ * 
+ * Licensed under the MIT License.
  */
 package redis.clients.authentication;
 

--- a/entraid/src/test/java/redis/clients/authentication/AzureIdentityProviderIntegrationTests.java
+++ b/entraid/src/test/java/redis/clients/authentication/AzureIdentityProviderIntegrationTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024, Redis Ltd. and Contributors All rights reserved. Licensed under the MIT License.
+ */
+package redis.clients.authentication;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+import redis.clients.authentication.core.Token;
+import redis.clients.authentication.entraid.AzureIdentityProvider;
+import redis.clients.authentication.entraid.AzureTokenAuthConfigBuilder;
+
+public class AzureIdentityProviderIntegrationTests {
+
+        @Test
+        public void requestTokenWithDefaultAzureCredential() {
+                // ensure environment variables are set
+                String client_id = System.getenv(TestContext.AZURE_CLIENT_ID);
+                assertNotNull(client_id);
+                assertFalse(client_id.isEmpty());
+                String clientSecret = System.getenv(TestContext.AZURE_CLIENT_SECRET);
+                assertNotNull(clientSecret);
+                assertFalse(clientSecret.isEmpty());
+                String tenantId = System.getenv("AZURE_TENANT_ID");
+                assertNotNull(tenantId);
+                assertFalse(tenantId.isEmpty());
+
+                DefaultAzureCredential defaultAzureCredential = new DefaultAzureCredentialBuilder().build();
+                Token token = new AzureIdentityProvider(defaultAzureCredential,
+                                AzureTokenAuthConfigBuilder.DEFAULT_SCOPES, 2000).requestToken();
+                assertNotNull(token.getValue());
+        }
+}

--- a/entraid/src/test/java/redis/clients/authentication/AzureIdentityProviderUnitTests.java
+++ b/entraid/src/test/java/redis/clients/authentication/AzureIdentityProviderUnitTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024, Redis Ltd. and Contributors
+ * All rights reserved.
+ *
+ * Licensed under the MIT License.
+ */
+package redis.clients.authentication;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.Set;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedConstruction;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.DefaultAzureCredential;
+
+import reactor.core.publisher.Mono;
+import redis.clients.authentication.entraid.AzureIdentityProvider;
+import redis.clients.authentication.entraid.AzureIdentityProviderConfig;
+import redis.clients.authentication.entraid.AzureTokenAuthConfigBuilder;
+
+public class AzureIdentityProviderUnitTests {
+    @Test
+    public void testAzureTokenAuthConfigBuilder() {
+        DefaultAzureCredential mockCredential = mock(DefaultAzureCredential.class);
+        Set<String> scopes = AzureTokenAuthConfigBuilder.DEFAULT_SCOPES;
+        int timeout = 2000;
+
+        try (MockedConstruction<AzureIdentityProviderConfig> mockedConstructor = mockConstruction(
+                AzureIdentityProviderConfig.class,
+                (mock, context) -> {
+                    assertEquals(mockCredential, context.arguments().get(0));
+                    assertEquals(scopes, context.arguments().get(1));
+                    assertEquals(timeout, context.arguments().get(2));
+                })) {
+            AzureTokenAuthConfigBuilder.builder().defaultAzureCredential(mockCredential).scopes(scopes)
+                    .tokenRequestExecTimeoutInMs(timeout).build();
+        }
+    }
+
+    public void testAzureIdentityProviderConfig() {
+        DefaultAzureCredential mockCredential = mock(DefaultAzureCredential.class);
+        Set<String> scopes = AzureTokenAuthConfigBuilder.DEFAULT_SCOPES;
+        int timeout = 2000;
+
+        try (MockedConstruction<AzureIdentityProvider> mockedConstructor = mockConstruction(
+                AzureIdentityProvider.class,
+                (mock, context) -> {
+                    assertEquals(mockCredential, context.arguments().get(0));
+                    assertEquals(scopes, context.arguments().get(1));
+                    assertEquals(timeout, context.arguments().get(2));
+                })) {
+            new AzureIdentityProviderConfig(mockCredential, scopes, timeout).getProvider();
+        }
+    }
+
+    @Test
+    public void testRequestWithMockCredential() {
+        String token = JWT.create().withExpiresAt(new Date(System.currentTimeMillis()
+                - 1000))
+                .withClaim("oid", "user1").sign(Algorithm.none());
+
+        AccessToken t = new AccessToken(token, OffsetDateTime.now());
+        Mono<AccessToken> monoToken = Mono.just(t);
+        DefaultAzureCredential mockCredential = mock(DefaultAzureCredential.class);
+        when(mockCredential.getToken(any(TokenRequestContext.class))).thenReturn(monoToken);
+        new AzureIdentityProviderConfig(mockCredential,
+                AzureTokenAuthConfigBuilder.DEFAULT_SCOPES, 0).getProvider().requestToken();
+
+        ArgumentCaptor<TokenRequestContext> argument = ArgumentCaptor.forClass(TokenRequestContext.class);
+
+        verify(mockCredential, atLeast(1)).getToken(argument.capture());
+        AzureTokenAuthConfigBuilder.DEFAULT_SCOPES
+                .forEach((item) -> assertTrue(argument.getValue().getScopes().contains(item)));
+    }
+}

--- a/entraid/src/test/java/redis/clients/authentication/TestContext.java
+++ b/entraid/src/test/java/redis/clients/authentication/TestContext.java
@@ -19,13 +19,13 @@ import java.security.spec.PKCS8EncodedKeySpec;
 
 public class TestContext {
 
-    private static final String AZURE_CLIENT_ID = "AZURE_CLIENT_ID";
-    private static final String AZURE_AUTHORITY = "AZURE_AUTHORITY";
-    private static final String AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET";
-    private static final String AZURE_PRIVATE_KEY = "AZURE_PRIVATE_KEY";
-    private static final String AZURE_CERT = "AZURE_CERT";
-    private static final String AZURE_REDIS_SCOPES = "AZURE_REDIS_SCOPES";
-    private static final String AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID = "AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID";
+    public static final String AZURE_CLIENT_ID = "AZURE_CLIENT_ID";
+    public static final String AZURE_AUTHORITY = "AZURE_AUTHORITY";
+    public static final String AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET";
+    public static final String AZURE_PRIVATE_KEY = "AZURE_PRIVATE_KEY";
+    public static final String AZURE_CERT = "AZURE_CERT";
+    public static final String AZURE_REDIS_SCOPES = "AZURE_REDIS_SCOPES";
+    public static final String AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID = "AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID";
 
     private String clientId;
     private String authority;


### PR DESCRIPTION
Azure offers a streamlined authentication solution for TBA scenarios through a unified construct called `DefaultAzureCredentials`. This approach consolidates multiple credential configurations commonly used in Azure-hosted environments, simplifying authentication management.
This pull request introduces support for `DefaultAzureCredentials` within our extension library.
More details on `DefaultAzureCredentials`;
https://learn.microsoft.com/en-us/java/api/com.azure.identity.defaultazurecredential?view=azure-java-stable
https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme?view=azure-java-stable