### PR TITLE
Fix clone method of AzureTokenAuthConfigBuilder

### DIFF
--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
@@ -109,7 +109,10 @@ public class AzureTokenAuthConfigBuilder extends TokenAuthConfig.Builder<AzureTo
                 .maxAttemptsToRetry(tokenManagerConfig.getRetryPolicy().getMaxAttempts())
                 .delayInMsToRetry(tokenManagerConfig.getRetryPolicy().getdelayInMs())
                 .identityProviderConfig(tokenAuthConfig.getIdentityProviderConfig());
+
+        builder.defaultAzureCredential = sample.defaultAzureCredential;
         builder.scopes = sample.scopes;
+        builder.tokenRequestExecTimeoutInMs = sample.tokenRequestExecTimeoutInMs;
         return builder;
     }
 }


### PR DESCRIPTION
fixes missing fields in cloned instance