### PR TITLE
Remove unused throws exception on close

### DIFF
--- a/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
+++ b/entraid/src/main/java/redis/clients/authentication/entraid/AzureTokenAuthConfigBuilder.java
@@ -52,7 +52,7 @@ public class AzureTokenAuthConfigBuilder extends TokenAuthConfig.Builder<AzureTo
     public static final int DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_IN_MS = 1000;
     public static final int DEFAULT_MAX_ATTEMPTS_TO_RETRY = 5;
     public static final int DEFAULT_DELAY_IN_MS_TO_RETRY = 100;
-    public static final Set<String> DEFAULT_SCOPES = Collections.singleton("https://redis.azure.com/.default");;
+    public static final Set<String> DEFAULT_SCOPES = Collections.singleton("https://redis.azure.com/.default");
 
     private DefaultAzureCredential defaultAzureCredential;
     private Set<String> scopes = DEFAULT_SCOPES;
@@ -89,7 +89,7 @@ public class AzureTokenAuthConfigBuilder extends TokenAuthConfig.Builder<AzureTo
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         defaultAzureCredential = null;
         scopes = null;
     }


### PR DESCRIPTION
AzureTokenAuthConfigBuilder.close method can not throw an exception.
Removing the throws clause no need to enforce exception handling.