### PR TITLE
Retry counter logic changed to count sequential retries only, and reset retries counter when token is fetched successfully

### DIFF
--- a/core/src/main/java/redis/clients/authentication/core/TokenManager.java
+++ b/core/src/main/java/redis/clients/authentication/core/TokenManager.java
@@ -15,17 +15,17 @@ public class TokenManager {
     private TokenManagerConfig tokenManagerConfig;
     private TokenListener listener;
     private boolean stopped = false;
-    private AtomicInteger numberOfRetries = new AtomicInteger(0);
+    private AtomicInteger numberOfSequentialRetries = new AtomicInteger(0);
     private Token currentToken = null;
     private AtomicBoolean started = new AtomicBoolean(false);
     private Dispatcher dispatcher;
     private RenewalScheduler renewalScheduler;
     private int retryDelay;
-    private int maxRetries;
+    private int maxSequentialRetries;
 
     public TokenManager(IdentityProvider identityProvider, TokenManagerConfig tokenManagerConfig) {
         this.tokenManagerConfig = tokenManagerConfig;
-        maxRetries = tokenManagerConfig.getRetryPolicy().getMaxAttempts();
+        maxSequentialRetries = tokenManagerConfig.getRetryPolicy().getMaxAttempts();
         retryDelay = tokenManagerConfig.getRetryPolicy().getdelayInMs();
         renewalScheduler = new RenewalScheduler(this::renewToken);
         dispatcher = new Dispatcher(identityProvider, tokenManagerConfig.getTokenRequestExecTimeoutInMs());
@@ -54,13 +54,13 @@ public class TokenManager {
     /**
      * This method is called by the renewal scheduler
      * Dispatches a request to the identity provider asynchronously, with a timeout for execution, and returns the Token if successfully acquired.
-     * If the request fails, it retries until the max number of retries is reached
-     * If the request fails after max number of retries, it throws an exception
+     * If the request fails, it retries until the max number of sequential retries is reached
+     * If the request fails after max number of sequential retries, it throws an exception
      * When a new Token is received, it schedules the next renewal with calculating the delay in respect to the new token.
      * Scheduling cycle only ends under two conditions:
      * 1. TokenManager is stopped
-     * 2. Token renewal fails for max number of retries 
-     * @return
+     * 2. Token renewal fails for max number of sequential retries
+     * @return refreshed token, or null
      */
     protected Token renewToken() {
         if (stopped) {
@@ -69,12 +69,14 @@ public class TokenManager {
         Token newToken = null;
         try {
             currentToken = newToken = dispatcher.requestTokenAsync().getResult();
+            numberOfSequentialRetries.set(0); // Reset sequential retries counter, as the token has been received
+                                              // successfully
             long delay = calculateRenewalDelay(newToken.getExpiresAt(), newToken.getReceivedAt());
             renewalScheduler.scheduleNext(delay);
             listener.onTokenRenewed(newToken);
             return newToken;
         } catch (Exception e) {
-            if (numberOfRetries.getAndIncrement() < maxRetries) {
+            if (numberOfSequentialRetries.getAndIncrement() < maxSequentialRetries) {
                 renewalScheduler.scheduleNext(retryDelay);
             } else {
                 RuntimeException propogateExc = prepareToPropogate(e);

--- a/core/src/test/java/redis/clients/authentication/CoreAuthenticationUnitTests.java
+++ b/core/src/test/java/redis/clients/authentication/CoreAuthenticationUnitTests.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -252,6 +253,63 @@ public class CoreAuthenticationUnitTests {
         await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
             verify(listener, times(1)).onTokenRenewed(any());
         });
+    }
+
+    @Test
+    public void testMaxRetriesExhausted() throws InterruptedException {
+        int maxRetries = 3;
+        int totalExpectedAttempts = maxRetries + 1;
+        CountDownLatch allAttemptsLatch = new CountDownLatch(totalExpectedAttempts);
+
+        IdentityProvider identityProvider = mock(IdentityProvider.class);
+        when(identityProvider.requestToken()).thenAnswer(invocation -> {
+            allAttemptsLatch.countDown();
+            throw new RuntimeException("Token request failed!");
+        });
+
+        TokenListener listener = mock(TokenListener.class);
+        TokenManager tokenManager = new TokenManager(identityProvider,
+                new TokenManagerConfig(0.7F, 200, 2000, new RetryPolicy(maxRetries, 50)));
+
+        tokenManager.start(listener, false);
+        allAttemptsLatch.await(5, TimeUnit.SECONDS);
+        delay(200);
+
+        verify(identityProvider, times(totalExpectedAttempts)).requestToken();
+        verify(listener, times(1)).onError(any());
+        verify(listener, never()).onTokenRenewed(any());
+    }
+
+    @Test
+    public void testRetriesCounterResetAfterSuccess() throws InterruptedException {
+        int maxRetries = 2;
+        int attemptsPerCycle = maxRetries + 1;
+        CountDownLatch successLatch = new CountDownLatch(2);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        IdentityProvider identityProvider = mock(IdentityProvider.class);
+        when(identityProvider.requestToken()).thenAnswer(invocation -> {
+            int call = callCount.incrementAndGet();
+            if (call % attemptsPerCycle != 0) {
+                throw new RuntimeException("Simulated failure");
+            }
+            successLatch.countDown();
+            return new SimpleToken("user1", "token" + call, System.currentTimeMillis() + 400,
+                    System.currentTimeMillis(), null);
+        });
+
+        TokenListener listener = mock(TokenListener.class);
+        TokenManager tokenManager = new TokenManager(identityProvider,
+                new TokenManagerConfig(0.5F, 0, 2000, new RetryPolicy(maxRetries, 50)));
+
+        tokenManager.start(listener, false);
+        successLatch.await(5, TimeUnit.SECONDS);
+        tokenManager.stop();
+        delay(100);
+
+        verify(identityProvider, times(2 * attemptsPerCycle)).requestToken();
+        verify(listener, never()).onError(any());
+        verify(listener, times(2)).onTokenRenewed(any());
     }
 
     private void delay(long durationInMs) {

--- a/core/src/test/java/redis/clients/authentication/CoreAuthenticationUnitTests.java
+++ b/core/src/test/java/redis/clients/authentication/CoreAuthenticationUnitTests.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -272,12 +273,13 @@ public class CoreAuthenticationUnitTests {
                 new TokenManagerConfig(0.7F, 200, 2000, new RetryPolicy(maxRetries, 50)));
 
         tokenManager.start(listener, false);
-        allAttemptsLatch.await(5, TimeUnit.SECONDS);
+        assertTrue(allAttemptsLatch.await(5, TimeUnit.SECONDS));
         delay(200);
 
         verify(identityProvider, times(totalExpectedAttempts)).requestToken();
         verify(listener, times(1)).onError(any());
         verify(listener, never()).onTokenRenewed(any());
+        tokenManager.stop();
     }
 
     @Test
@@ -294,7 +296,10 @@ public class CoreAuthenticationUnitTests {
                 throw new RuntimeException("Simulated failure");
             }
             successLatch.countDown();
-            return new SimpleToken("user1", "token" + call, System.currentTimeMillis() + 400,
+            // first success expires soon to trigger a second cycle; later successes get a
+            // long TTL so no further renewal can start before the test verifies call counts
+            long ttl = (call == attemptsPerCycle) ? 400 : 60_000;
+            return new SimpleToken("user1", "token" + call, System.currentTimeMillis() + ttl,
                     System.currentTimeMillis(), null);
         });
 
@@ -303,13 +308,14 @@ public class CoreAuthenticationUnitTests {
                 new TokenManagerConfig(0.5F, 0, 2000, new RetryPolicy(maxRetries, 50)));
 
         tokenManager.start(listener, false);
-        successLatch.await(5, TimeUnit.SECONDS);
-        tokenManager.stop();
-        delay(100);
+        assertTrue(successLatch.await(5, TimeUnit.SECONDS));
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(listener, times(2)).onTokenRenewed(any());
+        });
 
         verify(identityProvider, times(2 * attemptsPerCycle)).requestToken();
         verify(listener, never()).onError(any());
-        verify(listener, times(2)).onTokenRenewed(any());
+        tokenManager.stop();
     }
 
     private void delay(long durationInMs) {


### PR DESCRIPTION
### Proposed change
**New** behavior: count _sequential_ failures/retries while fetching a refreshed token form a token provider; throw an exception when max _sequential_ retries threshold reached.

**Current** behavior: counts _total_ number of failures/retries while fetching an access token from a token provider. All retries, even if non-sequential, are accounted towards max retries threshold.

### Rationale
Let's consider a scenario when there's a long-running service, with max retries set to 100, and we have the following timeline:
```
Day 1 
A web service fails to refresh a token 100 times, and uses exactly 100 retries till the token is refreshed. 
....
....
Day 20
After days of successful token refreshing the service unexpectedly observes one more failure to fetch a new token.
```
Current implementation would throw an exception on Day 20 (and abandon any retry attempts), because all the retry attempts were exhausted many many days before.

The proposed new behavior will instead start a _new_ retry sequence, up to max 100 sequential retries.

In my opinion, this proposed behavior may have significantly more sense for long-running services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running token refresh failure semantics in authentication core; misbehavior could stop renewal after transient outages, but scope is limited to retry accounting in `TokenManager`.
> 
> **Overview**
> **Token renewal retries** now apply only to **consecutive** failures within a single renewal attempt, instead of accumulating across the lifetime of the `TokenManager`.
> 
> On a successful token fetch in `renewToken()`, the retry counter is **reset to zero**, so intermittent failures after long periods of healthy renewals no longer inherit an exhausted budget from earlier bursts. Field and javadoc naming is updated to *sequential* retries; the configured max-attempts value from `RetryPolicy` is unchanged.
> 
> Two unit tests cover exhausting sequential retries (`maxRetries + 1` attempts, then `onError`) and resetting the counter across two renewal cycles (failures then success, repeated without hitting the cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 048b3a9374a46889386321b65de599cfe3b025d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->