### PR TITLE
Bump azure dependecies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,7 @@
   <packaging>jar</packaging>
   <groupId>redis.clients.authentication</groupId>
   <artifactId>redis-authx-core</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <description>Redis AuthX Core is the core lib of an extension for Redis Java  Clients to support token-based authentication.</description>
 	<url>https://github.com/redis/redis-authx-core</url>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,8 +56,6 @@
 		<github.global.server>github</github.global.server>
 		<core.module.name>redis.clients.authentication.core</core.module.name>
 		<slf4j.version>1.7.36</slf4j.version>
-		<resilience4j.version>1.7.1</resilience4j.version>
-		<jackson.version>2.18.0</jackson.version>
 		<maven.surefire.version>3.5.2</maven.surefire.version>
 	</properties>
 

--- a/entraid/pom.xml
+++ b/entraid/pom.xml
@@ -10,7 +10,7 @@
   <packaging>jar</packaging>
   <groupId>redis.clients.authentication</groupId>
   <artifactId>redis-authx-entraid</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <description>Redis AuthX EntraID is an extension for Redis Java  Clients to support token-based authentication with Microsoft EntraID.</description>
 	<url>https://github.com/redis/redis-authx-entraid</url>
 
@@ -73,12 +73,12 @@
 	<dependency>
 		<groupId>com.microsoft.azure</groupId>
 		<artifactId>msal4j</artifactId>
-		<version>1.19.1</version>
+		<version>1.26.0</version>
 	</dependency>
 	<dependency>
 		<groupId>com.azure</groupId>
 		<artifactId>azure-identity</artifactId>
-		<version>1.15.4</version>
+		<version>1.18.4</version>
 	</dependency>
     <dependency>
 		<groupId>junit</groupId>

--- a/entraid/src/test/java/redis/clients/authentication/TestContext.java
+++ b/entraid/src/test/java/redis/clients/authentication/TestContext.java
@@ -25,7 +25,6 @@ public class TestContext {
     public static final String AZURE_PRIVATE_KEY = "AZURE_PRIVATE_KEY";
     public static final String AZURE_CERT = "AZURE_CERT";
     public static final String AZURE_REDIS_SCOPES = "AZURE_REDIS_SCOPES";
-    public static final String AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID = "AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID";
 
     private String clientId;
     private String authority;
@@ -33,7 +32,6 @@ public class TestContext {
     private PrivateKey privateKey;
     private X509Certificate cert;
     private Set<String> redisScopes;
-    private String userAssignedManagedIdentityClientId;
 
     public static final TestContext DEFAULT = new TestContext();
 
@@ -42,7 +40,6 @@ public class TestContext {
         this.clientId = System.getenv(AZURE_CLIENT_ID);
         this.authority = System.getenv(AZURE_AUTHORITY);
         this.clientSecret = System.getenv(AZURE_CLIENT_SECRET);
-        this.userAssignedManagedIdentityClientId = System.getenv(AZURE_USER_ASSIGNED_MANAGED_IDENTITY_CLIENT_ID);
     }
 
     public TestContext(String clientId, String authority, String clientSecret, Set<String> redisScopes) {
@@ -84,10 +81,6 @@ public class TestContext {
             this.redisScopes = new HashSet<>(Arrays.asList(redisScopesEnv.split(";")));
         }
         return redisScopes;
-    }
-
-    public String getUserAssignedManagedIdentityClientId() {
-        return userAssignedManagedIdentityClientId;
     }
 
     private PrivateKey getPrivateKey(String privateKey) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>pom</packaging>
 	<groupId>redis.clients.authentication</groupId>
 	<artifactId>redis-authx</artifactId>
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 	<name>redis-authx</name>
 
 	<modules>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrading msal4j and azure-identity can change token acquisition behavior at runtime; the semver bump signals a minor release for consumers.
> 
> **Overview**
> Bumps the multi-module **redis-authx** line to **`0.2.0-SNAPSHOT`** and refreshes Microsoft Entra ID stack dependencies in **entraid**: **msal4j** `1.19.1` → `1.26.0` and **azure-identity** `1.15.4` → `1.18.4`.
> 
> **core** drops unused Maven property pins for **resilience4j** and **Jackson** (no dependency changes in that module). Entra ID integration tests shed unused **user-assigned managed identity** wiring from `TestContext` (env constant, field, and getter); production APIs like `userAssignedManagedIdentity` on the builder are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7415e1bb6bc2031ca3bae114e6fe55fa424e63dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->